### PR TITLE
Fix bug where .json files would throw error

### DIFF
--- a/bin/napkin.js
+++ b/bin/napkin.js
@@ -128,6 +128,16 @@ function referenceTracker(path) {
   }
 }
 
+function isJson(str) {
+  try {
+    JSON.parse(str);
+  } catch (e) {
+    return false;
+  }
+
+  return true;
+}
+
 function cleanCommentSymbols(comments) {
   const lineComments = comments.filter(c => c.type === "CommentLine");
   lineComments.forEach(comment => {
@@ -458,6 +468,12 @@ function parse(code, options = defaultParseOptions) {
   } = { ...defaultParseOptions,
     ...options
   };
+
+  if (isJson(code)) {
+    console.log('Skipping .json file');
+    return;
+  }
+
   classRefTracker.clear();
   return prettier__default['default'].format(code, {
     parser(text, {
@@ -524,15 +540,19 @@ if (require.main === module) {
    */
   (async function main() {
     const paths = await fs__default['default'].readdir(TARGET_DIR);
-    paths.forEach(async path => {
-      const data = await fs__default['default'].readFile(`${TARGET_DIR}/${path}`, {
+    paths.forEach(async filepath => {
+      if (path__default['default'].extname(filepath) !== '.js') {
+        return;
+      }
+
+      const data = await fs__default['default'].readFile(`${TARGET_DIR}/${filepath}`, {
         encoding: "utf8"
       });
       const result = parse(data, {
         usePrettier: usePretty,
         removeUnusedClasses: unusedClasses
       });
-      await fs__default['default'].writeFile(`${TARGET_DIR}/${path}`, buildComment(path) + result, {
+      await fs__default['default'].writeFile(`${TARGET_DIR}/${filepath}`, buildComment(filepath) + result, {
         encoding: "utf8"
       });
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lunatechs/lunatea-napkin",
-  "version": "1.5.0",
+  "version": "1.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lunatechs/lunatea-napkin",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "A wrapper around prettier's parser for transformation required by LunaTea",
   "main": "bin/napkin.js",
   "scripts": {

--- a/src/main.js
+++ b/src/main.js
@@ -29,8 +29,11 @@ if (require.main === module) {
    */
   (async function main() {
     const paths = await fs.readdir(TARGET_DIR);
-    paths.forEach(async (path) => {
-      const data = await fs.readFile(`${TARGET_DIR}/${path}`, {
+    paths.forEach(async (filepath) => {
+      if (path.extname(filepath) !== '.js') {
+        return;
+      }
+        const data = await fs.readFile(`${TARGET_DIR}/${filepath}`, {
         encoding: "utf8",
       });
 
@@ -39,7 +42,7 @@ if (require.main === module) {
         removeUnusedClasses: unusedClasses,
       });
 
-      await fs.writeFile(`${TARGET_DIR}/${path}`, buildComment(path) + result, {
+      await fs.writeFile(`${TARGET_DIR}/${filepath}`, buildComment(filepath) + result, {
         encoding: "utf8",
       });
     });

--- a/src/parse.js
+++ b/src/parse.js
@@ -3,6 +3,7 @@ import * as babelGenerator from "@babel/generator";
 import * as tt from "@babel/types";
 import prettier from "prettier";
 import { referenceTracker, classRefTracker } from "./referenceTracker";
+import isJson from './utils/isJson'
 
 import lunateaTransformer from "./lunateaTransformer";
 
@@ -24,6 +25,10 @@ export default function parse(code, options = defaultParseOptions) {
     ...defaultParseOptions,
     ...options,
   };
+  if (isJson(code)) {
+    console.log('Skipping .json file');
+    return
+  }
   classRefTracker.clear();
   return prettier.format(code, {
     parser(text, { babel }) {

--- a/src/utils/isJson.js
+++ b/src/utils/isJson.js
@@ -1,0 +1,8 @@
+export default function isJson (str) {
+  try {
+    JSON.parse(str);
+  } catch (e) {
+    return false;
+  }
+  return true;
+}

--- a/tests/fixtures/dummy.json
+++ b/tests/fixtures/dummy.json
@@ -1,0 +1,44 @@
+{
+  "name": "@lunatechs/lunatea-napkin",
+  "version": "1.5.1",
+  "description": "A wrapper around prettier's parser for transformation required by LunaTea",
+  "main": "bin/napkin.js",
+  "scripts": {
+    "test": "ava",
+    "lint": "npx eslint ./src/",
+    "build": "npx rollup -c"
+  },
+  "bin": {
+    "napkin": "./bin/napkin.js"
+  },
+  "files": [
+    "logo.png"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/LunaTechs/LunaTeaNapkin"
+  },
+  "author": "inc0der | LunaTechs",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/LunaTechsDev/LunaTeaNapkin/issues"
+  },
+  "homepage": "https://github.com/LunaTechsDev/LunaTeaNapkin#readme",
+  "dependencies": {
+    "@babel/core": "^7.11.6",
+    "@babel/generator": "^7.11.4",
+    "@babel/traverse": "^7.11.0",
+    "@babel/types": "^7.11.0",
+    "fs.promises": "^0.1.2",
+    "prettier": "^2.1.0",
+    "yargs": "^15.4.1"
+  },
+  "devDependencies": {
+    "@babel/cli": "^7.11.6",
+    "@babel/preset-env": "^7.11.5",
+    "@rollup/plugin-babel": "^5.2.1",
+    "ava": "^3.12.1",
+    "eslint": "^7.10.0",
+    "rollup": "^2.28.2"
+  }
+}

--- a/tests/test.js
+++ b/tests/test.js
@@ -83,7 +83,7 @@ test("Perform transformation without applying pretty styling", async (t) => {
   t.snapshot(result);
 });
 
-test("Ignores files that without an extension of .js", async (t) => {
+test("Ignores strings that are of json format", async (t) => {
   const originalData = await fs.readFile(`${FIXTURE_DIR}/dummy.json`, "utf8");
   try {
     const result = napkin.parse(originalData);

--- a/tests/test.js
+++ b/tests/test.js
@@ -82,3 +82,13 @@ test("Perform transformation without applying pretty styling", async (t) => {
   });
   t.snapshot(result);
 });
+
+test("Ignores files that without an extension of .js", async (t) => {
+  const originalData = await fs.readFile(`${FIXTURE_DIR}/dummy.json`, "utf8");
+  try {
+    const result = napkin.parse(originalData);
+    t.pass();
+  } catch (error) {
+    t.fail(error);
+  }
+});


### PR DESCRIPTION
This adds a check to ensure it skips skips .json strings and skips any file that is not .js when running in the `npakin` command.