### PR TITLE
Fix temp file error

### DIFF
--- a/bin/napkin.js
+++ b/bin/napkin.js
@@ -9,6 +9,7 @@ var tt = require('@babel/types');
 var prettier = require('prettier');
 var ts$1 = require('typescript');
 var fs = require('fs.promises');
+var temp = require('temp');
 var yargs = require('yargs');
 var path = require('path');
 
@@ -19,6 +20,7 @@ var babelGenerator__default = /*#__PURE__*/_interopDefaultLegacy(babelGenerator)
 var prettier__default = /*#__PURE__*/_interopDefaultLegacy(prettier);
 var ts__default = /*#__PURE__*/_interopDefaultLegacy(ts$1);
 var fs__default = /*#__PURE__*/_interopDefaultLegacy(fs);
+var temp__default = /*#__PURE__*/_interopDefaultLegacy(temp);
 var path__default = /*#__PURE__*/_interopDefaultLegacy(path);
 
 class ReferenceCounter {
@@ -524,16 +526,18 @@ function applyTextChanges(input, changes) {
   }, input);
 }
 
+temp__default['default'].track();
 async function organizeImports(code) {
   try {
-    const fileName = `${process.cwd()}/temp.js`;
+    const fileName = temp__default['default'].openSync({
+      suffix: '.js'
+    }).path;
     await fs.writeFile(fileName, code, "utf8");
     const languageService = ts__default['default'].createLanguageService(new ServiceHost(fileName, code));
     const fileChanges = languageService.organizeImports({
       type: 'file',
       fileName
     }, {}, {})[0];
-    await fs.unlink(fileName);
     return fileChanges ? applyTextChanges(code, fileChanges.textChanges) : code;
   } catch (error) {
     throw new Error(error.message);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lunatechs/lunatea-napkin",
-  "version": "1.5.2",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1834,8 +1834,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
       "version": "0.11.2",
@@ -1997,7 +1996,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2289,8 +2287,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concordance": {
       "version": "5.0.1",
@@ -3221,8 +3218,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "2.1.3",
@@ -3273,7 +3269,6 @@
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -3502,7 +3497,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -3511,8 +3505,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
       "version": "1.3.5",
@@ -4138,7 +4131,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -4185,7 +4177,6 @@
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "dev": true,
       "requires": {
         "minimist": "^1.2.5"
       }
@@ -4354,7 +4345,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -4559,8 +4549,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
       "version": "3.1.1",
@@ -5650,6 +5639,25 @@
         }
       }
     },
+    "temp": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
+      "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
+      "requires": {
+        "mkdirp": "^0.5.1",
+        "rimraf": "~2.6.2"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
     "temp-dir": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
@@ -6074,8 +6082,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@babel/types": "^7.11.0",
     "fs.promises": "^0.1.2",
     "prettier": "^2.1.0",
+    "temp": "^0.9.4",
     "typescript": "^4.3.5",
     "yargs": "^15.4.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lunatechs/lunatea-napkin",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A wrapper around prettier's parser for transformation required by LunaTea",
   "main": "bin/napkin.js",
   "scripts": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,6 +11,7 @@ export default {
     "@babel/generator",
     "prettier",
     "fs.promises",
+    "temp",
     "typescript"
   ],
   output: {

--- a/src/transforms/imports/organizeImports.js
+++ b/src/transforms/imports/organizeImports.js
@@ -1,12 +1,16 @@
 import ts from 'typescript';
-import { writeFile, unlink } from 'fs.promises';
+import { writeFile } from 'fs.promises';
+
+import temp from 'temp'
 
 import ServiceHost from './ServiceHost';
 import applyTextChanges from './applyTextChanges'
 
+temp.track();
+
 export default async function organizeImports(code) {
   try {
-    const fileName = `${process.cwd()}/temp.js`
+    const fileName = temp.openSync({ suffix: '.js' }).path
 
     await writeFile(fileName, code, "utf8");
 
@@ -15,8 +19,6 @@ export default async function organizeImports(code) {
       type: 'file',
       fileName
     }, {}, {})[0];
-
-    await unlink(fileName)
 
     return fileChanges ? applyTextChanges(code, fileChanges.textChanges) : code;
   } catch (error) {


### PR DESCRIPTION
A bug caused by using a temp file named `temp.js` would throw errors when attempting to remove it with consecutive runs of napkin.