### PR TITLE
Update temp cleanup

### DIFF
--- a/bin/napkin.js
+++ b/bin/napkin.js
@@ -538,6 +538,7 @@ async function organizeImports(code) {
       type: 'file',
       fileName
     }, {}, {})[0];
+    await temp__default['default'].cleanup();
     return fileChanges ? applyTextChanges(code, fileChanges.textChanges) : code;
   } catch (error) {
     throw new Error(error.message);

--- a/bin/napkin.js
+++ b/bin/napkin.js
@@ -620,6 +620,21 @@ async function parse(code, options = defaultParseOptions) {
   });
 }
 
+function addCleanupEvent(callback) {
+  process.on('cleanup', callback);
+}
+process.on('exit', function () {
+  process.emit('cleanup');
+});
+process.on('SIGINT', function () {
+  process.emit('cleanup');
+  process.exit(2);
+});
+process.on('uncaughtException', function () {
+  process.emit('cleanup');
+  process.exit(99);
+});
+
 const TARGET_DIR = yargs.argv.path ? path__default['default'].resolve(yargs.argv.path) : path__default['default'].resolve("dist");
 const usePretty = yargs.argv.pretty === undefined ? true : yargs.argv.pretty;
 const isPaper = yargs.argv.paper === undefined ? true : yargs.argv.paper;
@@ -646,7 +661,7 @@ if (require.main === module) {
   (async function main() {
     const paths = await fs__default['default'].readdir(TARGET_DIR);
     paths.forEach(async filepath => {
-      if (path__default['default'].extname(filepath) !== '.js') {
+      if (path__default['default'].extname(filepath) !== '.js' || /[temp]*\d{4,99}/.test(filepath)) {
         return;
       }
 
@@ -660,6 +675,14 @@ if (require.main === module) {
       });
       await fs__default['default'].writeFile(`${TARGET_DIR}/${filepath}`, buildComment(filepath) + result, {
         encoding: "utf8"
+      });
+    });
+    addCleanupEvent(async () => {
+      const paths = await fs__default['default'].readdir(TARGET_DIR);
+      paths.forEach(async filepath => {
+        if (/[temp]*\d{4,99}/.test(filepath)) {
+          await fs__default['default'].unlink(filepath);
+        }
       });
     });
   })().catch(error => {

--- a/src/cleanup.js
+++ b/src/cleanup.js
@@ -1,0 +1,17 @@
+export default function addCleanupEvent (callback) {
+  process.on('cleanup', callback);
+}
+
+process.on('exit', function () {
+  process.emit('cleanup');
+});
+
+process.on('SIGINT', function () {
+  process.emit('cleanup');
+  process.exit(2);
+});
+
+process.on('uncaughtException', function () {
+  process.emit('cleanup');
+  process.exit(99);
+});

--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,7 @@ import parse from "./parse";
 import { argv } from "yargs";
 import fs from "fs.promises";
 import path from "path";
+import addCleanupEvent from './cleanup';
 
 const TARGET_DIR = argv.path ? path.resolve(argv.path) : path.resolve("dist");
 const usePretty = argv.pretty === undefined ? true : argv.pretty;
@@ -48,6 +49,14 @@ if (require.main === module) {
         encoding: "utf8",
       });
     });
+    addCleanupEvent(async () => {
+      const paths = await fs.readdir(TARGET_DIR);
+      paths.forEach(async filepath => {
+        if (/[temp]*\d{4,99}/.test(filepath)) {
+          await fs.unlink(filepath);
+        }
+      })
+    })
   })().catch((error) => {
     process.exitCode = 1;
     console.error(error);

--- a/src/main.js
+++ b/src/main.js
@@ -31,7 +31,7 @@ if (require.main === module) {
   (async function main() {
     const paths = await fs.readdir(TARGET_DIR);
     paths.forEach(async (filepath) => {
-      if (path.extname(filepath) !== '.js') {
+      if (path.extname(filepath) !== '.js' || /[temp]*\d{4,99}/.test(filepath)) {
         return;
       }
         const data = await fs.readFile(`${TARGET_DIR}/${filepath}`, {

--- a/src/transforms/imports/organizeImports.js
+++ b/src/transforms/imports/organizeImports.js
@@ -20,6 +20,7 @@ export default async function organizeImports(code) {
       fileName
     }, {}, {})[0];
 
+    await temp.cleanup();
     return fileChanges ? applyTextChanges(code, fileChanges.textChanges) : code;
   } catch (error) {
     throw new Error(error.message);


### PR DESCRIPTION
- Utilizes the `temp` package(which created temp files)  `cleanup()`method for the import transformation process.

- Fixes bug where some temp files created in the target directory are left behind on process exit, or uncaught errors.

- Ignores temp files in the directory, so they're not parsed. This should improve performance.
