### PR TITLE
Add support for PaperTea file header

### DIFF
--- a/bin/napkin.js
+++ b/bin/napkin.js
@@ -641,13 +641,15 @@ const isPaper = yargs.argv.paper === undefined ? true : yargs.argv.paper;
 const unusedClasses = yargs.argv.unusedClasses === undefined ? true : yargs.argv.unusedClasses;
 
 const buildComment = filename => {
+  const title = isPaper ? 'OrigamiPlugins' : filename;
+  const madeWith = isPaper ? `Made with PaperTea -- Haxe` : `Made with LunaTea -- Haxe`;
   return `/** ============================================================================
  *
- *  ${filename}
+ *  ${title}
  * 
  *  Build Date: ${new Date().toLocaleDateString("en-US")}
  * 
- *  Made with LunaTea -- Haxe
+ *  ${madeWith}
  *
  * =============================================================================
 */

--- a/bin/napkin.js
+++ b/bin/napkin.js
@@ -639,9 +639,10 @@ const TARGET_DIR = yargs.argv.path ? path__default['default'].resolve(yargs.argv
 const usePretty = yargs.argv.pretty === undefined ? true : yargs.argv.pretty;
 const isPaper = yargs.argv.paper === undefined ? true : yargs.argv.paper;
 const unusedClasses = yargs.argv.unusedClasses === undefined ? true : yargs.argv.unusedClasses;
+const pluginName = yargs.argv.name;
 
 const buildComment = filename => {
-  const title = isPaper ? 'OrigamiPlugins' : filename;
+  const title = isPaper ? pluginName || 'OrigamiPlugins' : filename;
   const madeWith = isPaper ? `Made with PaperTea -- Haxe` : `Made with LunaTea -- Haxe`;
   return `/** ============================================================================
  *

--- a/bin/napkin.js
+++ b/bin/napkin.js
@@ -640,13 +640,14 @@ const usePretty = yargs.argv.pretty === undefined ? true : yargs.argv.pretty;
 const isPaper = yargs.argv.paper === undefined ? true : yargs.argv.paper;
 const unusedClasses = yargs.argv.unusedClasses === undefined ? true : yargs.argv.unusedClasses;
 const pluginName = yargs.argv.name;
+console.log(pluginName);
 
 const buildComment = filename => {
-  const title = isPaper ? pluginName || 'OrigamiPlugins' : filename;
+  const title = isPaper ? 'OrigamiPlugins' : filename;
   const madeWith = isPaper ? `Made with PaperTea -- Haxe` : `Made with LunaTea -- Haxe`;
   return `/** ============================================================================
  *
- *  ${title}
+ *  ${pluginName || title}
  * 
  *  Build Date: ${new Date().toLocaleDateString("en-US")}
  * 

--- a/src/main.js
+++ b/src/main.js
@@ -10,10 +10,11 @@ const usePretty = argv.pretty === undefined ? true : argv.pretty;
 const isPaper = argv.paper === undefined ? true : argv.paper;
 const unusedClasses =
   argv.unusedClasses === undefined ? true : argv.unusedClasses;
+const pluginName = argv.name;
 
   
   const buildComment = (filename) => {
-    const title = isPaper ? 'OrigamiPlugins' : filename;
+    const title = isPaper ? pluginName || 'OrigamiPlugins' : filename;
     const madeWith = isPaper ? `Made with PaperTea -- Haxe` : `Made with LunaTea -- Haxe`
   return `/** ============================================================================
  *

--- a/src/main.js
+++ b/src/main.js
@@ -11,14 +11,17 @@ const isPaper = argv.paper === undefined ? true : argv.paper;
 const unusedClasses =
   argv.unusedClasses === undefined ? true : argv.unusedClasses;
 
-const buildComment = (filename) => {
+  
+  const buildComment = (filename) => {
+    const title = isPaper ? 'OrigamiPlugins' : filename;
+    const madeWith = isPaper ? `Made with PaperTea -- Haxe` : `Made with LunaTea -- Haxe`
   return `/** ============================================================================
  *
- *  ${filename}
+ *  ${title}
  * 
  *  Build Date: ${new Date().toLocaleDateString("en-US")}
  * 
- *  Made with LunaTea -- Haxe
+ *  ${madeWith}
  *
  * =============================================================================
 */

--- a/src/main.js
+++ b/src/main.js
@@ -12,13 +12,13 @@ const unusedClasses =
   argv.unusedClasses === undefined ? true : argv.unusedClasses;
 const pluginName = argv.name;
 
-  
+  console.log(pluginName);
   const buildComment = (filename) => {
-    const title = isPaper ? pluginName || 'OrigamiPlugins' : filename;
+    const title = isPaper ? 'OrigamiPlugins' : filename;
     const madeWith = isPaper ? `Made with PaperTea -- Haxe` : `Made with LunaTea -- Haxe`
   return `/** ============================================================================
  *
- *  ${title}
+ *  ${pluginName || title}
  * 
  *  Build Date: ${new Date().toLocaleDateString("en-US")}
  * 


### PR DESCRIPTION
Adds support to the file header generated when parsed. 

- Will now say `Made with PaperTea` 

- It will replace filename `code.js` file name for `OrigamiPlugins` or if you used the `--name=PluginName` argument then it will use that instead.